### PR TITLE
feat(worker): return fetch event handler

### DIFF
--- a/.changeset/eighty-swans-mate.md
+++ b/.changeset/eighty-swans-mate.md
@@ -1,0 +1,5 @@
+---
+'@benzene/worker': minor
+---
+
+Change @benzene/worker function to return a fetch event handler

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+codecov:
+  branch: main

--- a/docs/worker/README.md
+++ b/docs/worker/README.md
@@ -52,6 +52,7 @@ See [Using Web Workers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Wor
 
 | options | description | default |
 |---------|-------------|---------|
+| path | Specify a path for the GraphQL endpoint. If supplied `@benzene/worker` will ignore requests to different pathname. If not, **`@benzene/worker`** will intercept all requests (which is **not** desired) | `undefined` |
 | context | An object or function called to creates a context shared across resolvers per request. The function accepts [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) as the only argument. | `{}` |
 
 It returns a promise that resolves with [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) to be used in `event.respondWith`.

--- a/docs/worker/README.md
+++ b/docs/worker/README.md
@@ -79,6 +79,6 @@ const gqlHandle = fetchHandler(GQL, {
 
 ### My web worker(s) already have a fetch event handler
 
-It is possible to have multiple fetch event handlers within a service worker. The second handler gets its chance to call `event.respondWith()` only if the previous did not. 
+It is possible to have multiple fetch event handlers within a service worker. The second handler gets its chance to call `event.respondWith()` only if the previous one does not. 
 
-If `path` does not match, `gqlHandle` will simply return. letting other fetch event handler to work. See this [demo](https://googlechrome.github.io/samples/service-worker/multiple-handlers/index.html) for demonstration.
+If `path` does not match, `gqlHandle` will simply return, letting other fetch event handler to work. See this [demo](https://googlechrome.github.io/samples/service-worker/multiple-handlers/index.html) for demonstration.

--- a/packages/worker/src/handler.ts
+++ b/packages/worker/src/handler.ts
@@ -7,56 +7,60 @@ import {
 } from '@benzene/core';
 import { HandlerConfig } from './types';
 
-export async function handleRequest(
-  gql: GraphQL,
-  request: Request,
-  options: HandlerConfig = {}
-): Promise<Response> {
-  let requestBody: Record<string, any> | null = null;
+export function createHandler(gql: GraphQL, options: HandlerConfig = {}) {
+  async function handleRequest(request: Request) {
+    let requestBody: Record<string, any> | null = null;
 
-  if (request.method === 'POST') {
-    const oCtype = request.headers.get('content-type');
-    if (oCtype) {
-      try {
-        requestBody = parseBodyByContentType(await request.text(), oCtype);
-      } catch (err) {
-        return new Response(err.message, {
-          status: 400,
-          headers: { 'content-type': 'text/plain' },
-        });
+    if (request.method === 'POST') {
+      const oCtype = request.headers.get('content-type');
+      if (oCtype) {
+        try {
+          requestBody = parseBodyByContentType(await request.text(), oCtype);
+        } catch (err) {
+          return new Response(err.message, {
+            status: 400,
+            headers: { 'content-type': 'text/plain' },
+          });
+        }
       }
     }
-  }
 
-  const queryParams: { [key: string]: string } = {};
+    const queryParams: { [key: string]: string } = {};
 
-  new URLSearchParams(request.url.slice(request.url.indexOf('?'))).forEach(
-    (value, key) => (queryParams[key] = value)
-  );
-
-  const params = getGraphQLParams({
-    queryParams,
-    body: requestBody,
-  }) as HttpQueryRequest;
-  params.httpMethod = request.method;
-
-  try {
-    params.context =
-      typeof options.context === 'function'
-        ? await options.context(request)
-        : options.context || {};
-  } catch (err) {
-    err.message = `Context creation failed: ${err.message}`;
-    return new Response(
-      JSON.stringify(gql.formatExecutionResult({ errors: [err] })),
-      {
-        status: err.status || 500,
-        headers: { 'content-type': 'application/json' },
-      }
+    new URLSearchParams(request.url.slice(request.url.indexOf('?'))).forEach(
+      (value, key) => (queryParams[key] = value)
     );
+
+    const params = getGraphQLParams({
+      queryParams,
+      body: requestBody,
+    }) as HttpQueryRequest;
+    params.httpMethod = request.method;
+
+    try {
+      params.context =
+        typeof options.context === 'function'
+          ? await options.context(request)
+          : options.context || {};
+    } catch (err) {
+      err.message = `Context creation failed: ${err.message}`;
+      return new Response(
+        JSON.stringify(gql.formatExecutionResult({ errors: [err] })),
+        {
+          status: err.status || 500,
+          headers: { 'content-type': 'application/json' },
+        }
+      );
+    }
+
+    const { status, body, headers } = await runHttpQuery(gql, params);
+
+    return new Response(body, { status, headers });
   }
 
-  const { status, body, headers } = await runHttpQuery(gql, params);
-
-  return new Response(body, { status, headers });
+  return function handler(event: FetchEvent) {
+    if (options.path && options.path !== new URL(event.request.url).pathname)
+      return;
+    event.respondWith(handleRequest(event.request));
+  };
 }

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -1,2 +1,2 @@
 export { GraphQL } from '@benzene/core';
-export { handleRequest } from './handler';
+export { createHandler as fetchHandler } from './handler';

--- a/packages/worker/src/types.ts
+++ b/packages/worker/src/types.ts
@@ -1,5 +1,6 @@
 import { ValueOrPromise, TContext } from '@benzene/core';
 
 export interface HandlerConfig {
+  path?: string;
   context?: TContext | ((request: Request) => ValueOrPromise<TContext>);
 }

--- a/packages/worker/tests/worker.spec.ts
+++ b/packages/worker/tests/worker.spec.ts
@@ -182,16 +182,29 @@ describe('worker: fetchHandler', () => {
     });
   });
 
-  describe('do nothing if path does not match', () => {
+  describe('When options.path is set', () => {
     const gql = new GraphQL({ schema });
-    const fetchEvent: FetchEvent = {
-      // @ts-ignore
-      request: new fetch.Request('http://localhost:0/notAPI'),
-      respondWith: (maybeResponse) => {
-        throw new Error("DON'T CALL ME! WE ALREADY BROKE UP.");
-      },
-    };
-    fetchHandler(gql, { path: '/api' })(fetchEvent);
-    return;
+    it('ignore requests of different path', (done) => {
+      const badFetchEvent: FetchEvent = {
+        // @ts-ignore
+        request: new fetch.Request('http://localhost:0/notAPI'),
+        respondWith: (maybeResponse) => {
+          throw new Error("DON'T CALL ME! WE ALREADY BROKE UP.");
+        },
+      };
+      fetchHandler(gql, { path: '/api' })(badFetchEvent);
+      done();
+    });
+    it('response to requests to defined path', (done) => {
+      const correctFetchEvent: FetchEvent = {
+        // @ts-ignore
+        request: new fetch.Request('http://localhost:0/api'),
+        respondWith: async (maybeResponse) => {
+          done();
+          return maybeResponse;
+        },
+      };
+      fetchHandler(gql, { path: '/api' })(correctFetchEvent);
+    });
   });
 });

--- a/packages/worker/tests/worker.spec.ts
+++ b/packages/worker/tests/worker.spec.ts
@@ -2,7 +2,12 @@ import { makeExecutableSchema } from '@graphql-tools/schema';
 import * as fetch from 'node-fetch';
 import { strict as assert } from 'assert';
 import { HttpQueryResponse } from '@benzene/core/src';
-import { GraphQL, handleRequest } from '../src';
+import { GraphQL, fetchHandler } from '../src';
+
+interface FetchEvent {
+  request: Request;
+  respondWith(response: Promise<Response> | Response): Promise<Response>;
+}
 
 const schema = makeExecutableSchema({
   typeDefs: `
@@ -29,22 +34,22 @@ async function testRequest(
 ) {
   const gql = new GraphQL({ schema });
   return new Promise((resolve, reject) => {
-    const fetchEvent = {
+    const fetchEvent: FetchEvent = {
+      // @ts-ignore
       request: new fetch.Request(
         input.startsWith('/') ? `http://localhost:0${input}` : input,
         init
       ),
-    };
-    // @ts-ignore
-    // Mock Web Request using node-fetch Request
-    handleRequest(gql, fetchEvent.request as Request, handlerOptions).then(
-      async (response) => {
+      respondWith: async (maybeResponse) => {
+        const response = await maybeResponse;
         if (expected.body)
           assert.strictEqual(expected.body, await response.text());
         assert.strictEqual(expected.status || 200, response.status);
         resolve();
-      }
-    );
+        return response;
+      },
+    };
+    fetchHandler(gql, handlerOptions)(fetchEvent);
   });
 }
 
@@ -55,7 +60,7 @@ before(() => {
   global.Response = fetch.Response;
 });
 
-describe('worker: handleRequest', () => {
+describe('worker: fetchHandler', () => {
   it('works with queryParams', async () => {
     await testRequest(
       '/graphql?query={ hello }',
@@ -175,5 +180,18 @@ describe('worker: handleRequest', () => {
         { context: async () => ({ me: 'hoang' }) }
       );
     });
+  });
+
+  describe('do nothing if path does not match', () => {
+    const gql = new GraphQL({ schema });
+    const fetchEvent: FetchEvent = {
+      // @ts-ignore
+      request: new fetch.Request('http://localhost:0/notAPI'),
+      respondWith: (maybeResponse) => {
+        throw new Error("DON'T CALL ME! WE ALREADY BROKE UP.");
+      },
+    };
+    fetchHandler(gql, { path: '/api' })(fetchEvent);
+    return;
   });
 });


### PR DESCRIPTION
This changes the previous approach from using `handleRequest(GQL, request, options)` to using the new `fetchHandler` function which return a function to be given to `addEventListener('fetch', fn)`