### PR TITLE
Enforce GraphQL response format on error

### DIFF
--- a/.changeset/light-kiwis-accept.md
+++ b/.changeset/light-kiwis-accept.md
@@ -1,0 +1,7 @@
+---
+'@benzene/core': minor
+'@benzene/server': minor
+'@benzene/worker': minor
+---
+
+Enforce GraphQL response format on error

--- a/README.md
+++ b/README.md
@@ -26,19 +26,19 @@ There are currently three packages under `@benzene`.
 
 Fast and simple GraphQL Server for Node.js
 
-[Documentation](server/) [npm](https://www.npmjs.com/package/@benzene/server) [yarn](https://yarnpkg.com/package/@benzene/server)
+[Documentation](https://hoangvvo.github.io/benzene/#/server/) [npm](https://www.npmjs.com/package/@benzene/server) [yarn](https://yarnpkg.com/package/@benzene/server)
 
 ### Worker (`@benzene/worker`)
 
 GraphQL server right in the browser ([Web Workers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API)) or at the edge ([Cloudflare Workers®](https://workers.cloudflare.com/))
 
-[Documentation](worker/) [npm](https://www.npmjs.com/package/@benzene/worker) [yarn](https://yarnpkg.com/package/@benzene/worker)
+[Documentation](https://hoangvvo.github.io/benzene/#/worker/) [npm](https://www.npmjs.com/package/@benzene/worker) [yarn](https://yarnpkg.com/package/@benzene/worker)
 
-### WebSocket
+### WebSocket (`@benzene/ws`)
 
 GraphQL over WebSocket using [`ws`](https://github.com/websockets/worker)
 
-[Documentation](ws/) [npm](https://www.npmjs.com/package/@benzene/ws) [yarn](https://yarnpkg.com/package/@benzene/ws)
+[Documentation](https://hoangvvo.github.io/benzene/#/ws/) [npm](https://www.npmjs.com/package/@benzene/ws) [yarn](https://yarnpkg.com/package/@benzene/ws)
 
 ## Examples
 

--- a/docs/core/README.md
+++ b/docs/core/README.md
@@ -86,11 +86,6 @@ const GQL = new GraphQL({
 });
 ```
 
-This applies everywhere that uses the `GraphQL` instance. Some errors that are never included are:
-
-- body parsing error
-- No provided query
-
 ## RootValue
 
 `options.rootValue` defines away to supply a `rootValue` to the GraphQL execution. While this value is not mentioned anywhere and the official document, this [Stackoverflow answer](https://stackoverflow.com/a/53987189/14114942) provides some insight.

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -16,7 +16,11 @@ export function parseBodyByContentType(
     case 'application/graphql':
       return { query: rawBody };
     case 'application/json':
-      return JSON.parse(rawBody);
+      try {
+        return JSON.parse(rawBody);
+      } catch (e) {
+        throw new Error('POST body sent invalid JSON.');
+      }
     default:
       // If no Content-Type header matches, parse nothing.
       return null;

--- a/packages/core/tests/core.spec.ts
+++ b/packages/core/tests/core.spec.ts
@@ -162,8 +162,8 @@ describe('core: runHttpQuery', () => {
       { context: {} },
       {
         status: 400,
-        body: 'Must provide query string.',
-        headers: { 'content-type': 'text/plain' },
+        body: '{"errors":[{"message":"Must provide query string."}]}',
+        headers: { 'content-type': 'application/json' },
       }
     );
   });
@@ -175,8 +175,9 @@ describe('core: runHttpQuery', () => {
       },
       {
         status: 405,
-        body: 'Operation mutation cannot be performed via a GET request.',
-        headers: { 'content-type': 'text/plain' },
+        body:
+          '{"errors":[{"message":"Can only perform a mutation operation from a POST request."}]}',
+        headers: { 'content-type': 'application/json' },
       }
     );
   });
@@ -188,8 +189,9 @@ describe('core: runHttpQuery', () => {
       },
       {
         status: 405,
-        body: 'GraphQL only supports GET and POST requests.',
-        headers: { 'content-type': 'text/plain' },
+        body:
+          '{"errors":[{"message":"GraphQL only supports GET and POST requests."}]}',
+        headers: { 'content-type': 'application/json' },
       }
     );
   });

--- a/packages/server/tests/http.spec.ts
+++ b/packages/server/tests/http.spec.ts
@@ -66,7 +66,12 @@ describe('server/http: httpHandler', () => {
       .post('/graphql')
       .set('content-type', 'application/json')
       .send('{ as')
-      .expect(400);
+      .expect(400)
+      .expect(
+        JSON.stringify({
+          errors: [{ message: 'POST body sent invalid JSON.' }],
+        })
+      );
   });
   it('catches error thrown in context function', async () => {
     const server = createGQLServer(

--- a/packages/worker/src/handler.ts
+++ b/packages/worker/src/handler.ts
@@ -18,9 +18,11 @@ export function createHandler(gql: GraphQL, options: HandlerConfig = {}) {
           requestBody = parseBodyByContentType(await request.text(), oCtype);
         } catch (err) {
           return new Response(
-            JSON.stringify({
-              errors: [{ message: err.message }],
-            }),
+            JSON.stringify(
+              gql.formatExecutionResult({
+                errors: [err],
+              })
+            ),
             {
               status: 400,
               headers: { 'content-type': 'application/json' },

--- a/packages/worker/src/handler.ts
+++ b/packages/worker/src/handler.ts
@@ -17,10 +17,15 @@ export function createHandler(gql: GraphQL, options: HandlerConfig = {}) {
         try {
           requestBody = parseBodyByContentType(await request.text(), oCtype);
         } catch (err) {
-          return new Response(err.message, {
-            status: 400,
-            headers: { 'content-type': 'text/plain' },
-          });
+          return new Response(
+            JSON.stringify({
+              errors: [{ message: err.message }],
+            }),
+            {
+              status: 400,
+              headers: { 'content-type': 'application/json' },
+            }
+          );
         }
       }
     }

--- a/packages/worker/tests/worker.spec.ts
+++ b/packages/worker/tests/worker.spec.ts
@@ -111,7 +111,9 @@ describe('worker: fetchHandler', () => {
         {
           status: 400,
           // Because body is not parsed, query string cannot be read
-          body: `Must provide query string.`,
+          body: JSON.stringify({
+            errors: [{ message: 'Must provide query string.' }],
+          }),
         }
       );
     });
@@ -122,7 +124,9 @@ describe('worker: fetchHandler', () => {
       '/graphql',
       {},
       {
-        body: `Must provide query string.`,
+        body: JSON.stringify({
+          errors: [{ message: 'Must provide query string.' }],
+        }),
         status: 400,
       }
     );
@@ -134,9 +138,14 @@ describe('worker: fetchHandler', () => {
       {
         body: `query { helloWorld`,
         method: 'POST',
-        headers: { 'content-type': 'application/json; t' },
+        headers: { 'content-type': 'application/json' },
       },
-      { status: 400 }
+      {
+        status: 400,
+        body: JSON.stringify({
+          errors: [{ message: 'POST body sent invalid JSON.' }],
+        }),
+      }
     );
   });
 


### PR DESCRIPTION
This PR enforces that every response, even errors not in GraphQL resolver, must be in the form of a GraphQL response.