### PR TITLE
(ws) Add onStart and onComplete Hook API

### DIFF
--- a/.changeset/two-teachers-juggle.md
+++ b/.changeset/two-teachers-juggle.md
@@ -1,0 +1,5 @@
+---
+'@benzene/ws': patch
+---
+
+(ws) Add onStart and onComplete Hook API (#10)

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -34,6 +34,7 @@
     - [Usage](ws/#usage)
     - [API](ws/#api)
     - [Building Context](ws/#context)
+    - [Hooks](ws/#hooks)
   - [Authentication](ws/#authentication)
   - [Protocol](ws/PROTOCOL)
   - [Integration](ws/ws-integration)

--- a/docs/ws/README.md
+++ b/docs/ws/README.md
@@ -71,9 +71,9 @@ wss.on('connection', wsHandler(GQL, options));
 
 ### wsHandler(GQL, options)
 
-Create a handler for incoming WebSocket connection (from `wss.on('connection')`) and execute GraphQL based on [GraphQL over WebSocket Protocol](https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md).
+Create a handler for incoming WebSocket connection (from `wss.on('connection')`) and execute GraphQL based on the [modified GraphQL over WebSocket Protocol](https://github.com/hoangvvo/benzene/blob/main/packages/ws/PROTOCOL.md).
 
-`GQL` in a [Benzene GraphQL instance](/core/) instance.
+`GQL` is a [Benzene GraphQL instance](/core/) instance.
 
 ?> It is recommended to read about `GraphQL` instance in the [Core Section](core/) first.
 
@@ -82,8 +82,8 @@ Create a handler for incoming WebSocket connection (from `wss.on('connection')`)
 | options | description | default |
 |---------|-------------|---------|
 | context | An object or function called to creates a context shared across resolvers per connection. The function is called with the arguments [socket](https://github.com/websockets/ws/blob/master/doc/ws.md#class-websocket), [IncomingMessage](https://nodejs.org/api/http.html#http_class_http_incomingmessage) | `{}` |
-| onStart | (Experimental) A function to be called when a subscription (or query/execution) started (or executed). See [`Hook`](#hooks). | `undefined` |
-| onStop | (Experimental) A function to be called when a subscription (or query/execution) finished (or right after their execution). See [`Hook`](#hooks). | `undefined` |
+| onStart | (Experimental) A function to be called when a subscription (or query/execution) started (or executed). See [`Hooks`](#hooks). | `undefined` |
+| onComplete | (Experimental) A function to be called when a subscription (or query/execution) finished (or after their execution which is immediate). See [`Hooks`](#hooks). | `undefined` |
 
 ## Building Context :id=context
 
@@ -118,11 +118,11 @@ See [Authentication](/ws/authentication) on possible authentication mechanism.
 
 ## Hooks
 
-!> This API is experimental and may be modified/removed in a future version. See [#9](https://github.com/hoangvvo/benzene/issues/9). These are hooks are for **listening only**.
+!> This API is experimental and may be modified/removed in a future version. See [#9](https://github.com/hoangvvo/benzene/issues/9).
 
 ### Subscription Start
 
-When a subscription is started, `options.onStart` will be called with a unique subscription `id` and an `execArg` object containing `document`, `contextValue`, `variableValues`, and `operationName`. 
+When a subscription **have started** (not before, so you cannot mutate the request), `options.onStart` will be called with a unique subscription `id` and an `execArg` object containing `document`, `contextValue`, `variableValues`, and `operationName`.
 
 The function is called with `this = SubscriptionConnection` (except [arrow function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)). 
 
@@ -146,14 +146,14 @@ const wsHandle = wsHandler(GQL, {
 });
 ```
 
-### Subscription Stop
+### Subscription Complete
 
-When a subscription is completed/finished, `options.onStart` will be called with tehe unique subscription `id`. Similarly, you have access to `SubscriptionConnection` via `this`.
+When a subscription have completed/finished, `options.onComplete` will be called with tehe unique subscription `id`. Similarly, you have access to `SubscriptionConnection` via `this`.
 
 ```js
 const wsHandle = wsHandler(GQL, {
   /* Continue the above */
-  onStop(id) {
+  onComplete(id) {
     const roomPresence = this[CONN_STATE][`roomPresence`];
     if (roomPresence && id === roomPresence.subId) {
       // User unsubscribe from onRoomUpdated, meaning he/she is leaving

--- a/packages/ws/src/connection.ts
+++ b/packages/ws/src/connection.ts
@@ -119,7 +119,7 @@ export class SubscriptionConnection {
       }
     }
     // Complete
-    if (this.options.onStop) this.options.onStop.call(this, data.id);
+    if (this.options.onComplete) this.options.onComplete.call(this, data.id);
     this.sendMessage(MessageTypes.GQL_COMPLETE, data.id);
   }
 

--- a/packages/ws/src/handler.ts
+++ b/packages/ws/src/handler.ts
@@ -41,7 +41,7 @@ export function createHandler(gql: GraphQL, options: HandlerConfig = {}) {
     socket.off('message', queueUnhandled);
     const connection = new SubscriptionConnection(gql, socket, context, {
       onStart: options.onStart,
-      onStop: options.onStop,
+      onComplete: options.onComplete,
     });
     // Flush all queued unhandled message
     for (let i = 0; i < unhandledQueue.length; i += 1) {

--- a/packages/ws/src/handler.ts
+++ b/packages/ws/src/handler.ts
@@ -4,7 +4,6 @@ import * as WebSocket from 'ws';
 import { SubscriptionConnection } from './connection';
 import MessageTypes, { GRAPHQL_WS } from './messageTypes';
 import { HandlerConfig } from './types';
-import { connect } from 'http2';
 
 export function createHandler(gql: GraphQL, options: HandlerConfig = {}) {
   async function handleSocket(

--- a/packages/ws/src/handler.ts
+++ b/packages/ws/src/handler.ts
@@ -4,6 +4,7 @@ import * as WebSocket from 'ws';
 import { SubscriptionConnection } from './connection';
 import MessageTypes, { GRAPHQL_WS } from './messageTypes';
 import { HandlerConfig } from './types';
+import { connect } from 'http2';
 
 export function createHandler(gql: GraphQL, options: HandlerConfig = {}) {
   async function handleSocket(
@@ -38,7 +39,10 @@ export function createHandler(gql: GraphQL, options: HandlerConfig = {}) {
 
     // No longer need to queue
     socket.off('message', queueUnhandled);
-    const connection = new SubscriptionConnection(gql, socket, context);
+    const connection = new SubscriptionConnection(gql, socket, context, {
+      onStart: options.onStart,
+      onStop: options.onStop,
+    });
     // Flush all queued unhandled message
     for (let i = 0; i < unhandledQueue.length; i += 1) {
       // FIXME: Need test for this behavior

--- a/packages/ws/src/types.ts
+++ b/packages/ws/src/types.ts
@@ -2,6 +2,8 @@ import { GraphQLParams, ValueOrPromise, TContext } from '@benzene/core';
 import * as WebSocket from 'ws';
 import { IncomingMessage } from 'http';
 import MessageTypes from './messageTypes';
+import { DocumentNode } from 'graphql';
+import { SubscriptionConnection } from './connection';
 
 type MessageType = typeof MessageTypes[keyof typeof MessageTypes];
 
@@ -18,4 +20,15 @@ export interface HandlerConfig {
         socket: WebSocket,
         request: IncomingMessage
       ) => ValueOrPromise<TContext>);
+  onStart?: (
+    this: SubscriptionConnection,
+    id: string,
+    execArg: {
+      document: DocumentNode;
+      contextValue: TContext;
+      variableValues: Record<string, any> | null | undefined;
+      operationName: string | null | undefined;
+    }
+  ) => void;
+  onStop?: (this: SubscriptionConnection, id: string) => void;
 }

--- a/packages/ws/src/types.ts
+++ b/packages/ws/src/types.ts
@@ -30,5 +30,5 @@ export interface HandlerConfig {
       operationName: string | null | undefined;
     }
   ) => void;
-  onStop?: (this: SubscriptionConnection, id: string) => void;
+  onComplete?: (this: SubscriptionConnection, id: string) => void;
 }

--- a/packages/ws/tests/ws.spec.ts
+++ b/packages/ws/tests/ws.spec.ts
@@ -758,11 +758,11 @@ connSuite('call onStart on execution', async () => {
   });
 });
 
-connSuite('call onStop on subscription stop', async () => {
+connSuite('call onComplete on subscription stop', async () => {
   // eslint-disable-next-line no-async-promise-executor
   return new Promise(async (resolve) => {
     const { client } = await startServer({
-      onStop(id) {
+      onComplete(id) {
         assert.instance(this, SubscriptionConnection);
         assert.is(id, 1);
         resolve();


### PR DESCRIPTION
This adds two new hooks in `ws`: `onStart` and `onComplete`. They are experimental (See #9).