### PR TITLE
fix(ws): Close operations properly on connection closure

### DIFF
--- a/.changeset/forty-readers-travel.md
+++ b/.changeset/forty-readers-travel.md
@@ -1,0 +1,5 @@
+---
+'@benzene/ws': patch
+---
+
+Close operations properly on connection closure

--- a/packages/ws/src/connection.ts
+++ b/packages/ws/src/connection.ts
@@ -21,9 +21,7 @@ export class SubscriptionConnection {
     public socket: WebSocket,
     public context: TContext,
     private listeners: Pick<HandlerConfig, 'onStart' | 'onComplete'>
-  ) {}
-
-  init() {
+  ) {
     // Listen to events
     this.socket.on('message', (data) => this.onMessage(data.toString()));
     this.socket.on('error', () => this.socket.close());

--- a/packages/ws/src/connection.ts
+++ b/packages/ws/src/connection.ts
@@ -142,7 +142,7 @@ export class SubscriptionConnection {
   handleConnectionClose() {
     // Unsubscribe from the whole socket
     // This makes sure each async iterators are returned
-    Object.keys(this.operations).forEach((opId) => this.handleGQLStop(opId));
+    for (const opId of this.operations.keys()) this.handleGQLStop(opId);
     this.socket.close();
   }
 

--- a/packages/ws/src/handler.ts
+++ b/packages/ws/src/handler.ts
@@ -21,7 +21,6 @@ export function createHandler(gql: GraphQL, options: HandlerConfig = {}) {
     const unhandledQueue: string[] = [];
     const queueUnhandled = (data: WebSocket.Data) =>
       unhandledQueue.push(data.toString());
-
     socket.on('message', queueUnhandled);
 
     let context: TContext = {};
@@ -53,11 +52,7 @@ export function createHandler(gql: GraphQL, options: HandlerConfig = {}) {
       onComplete: options.onComplete,
     });
     // Flush all queued message
-    for (let i = 0; i < unhandledQueue.length; i += 1) {
-      // FIXME: Need test for this behavior
-      connection.onMessage(unhandledQueue[i]);
-    }
-
-    connection.init();
+    for (const unhandleMessage of unhandledQueue)
+      connection.onMessage(unhandleMessage);
   };
 }

--- a/packages/ws/src/handler.ts
+++ b/packages/ws/src/handler.ts
@@ -52,10 +52,10 @@ export function createHandler(gql: GraphQL, options: HandlerConfig = {}) {
       onStart: options.onStart,
       onComplete: options.onComplete,
     });
-    // Flush all queued unhandled message
+    // Flush all queued message
     for (let i = 0; i < unhandledQueue.length; i += 1) {
       // FIXME: Need test for this behavior
-      connection.handleMessage(unhandledQueue[i]);
+      connection.onMessage(unhandledQueue[i]);
     }
 
     connection.init();


### PR DESCRIPTION
This fixes an error that cause `connection.operations` to not be iterated properly.