### PR TITLE
Return object payload for runHttpQuery

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,7 +14,9 @@
   "homepage": "https://hoangvvo.github.io/benzene/",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "test": "uvu -r ts-node/register/transpile-only"
@@ -22,7 +24,6 @@
   "license": "MIT",
   "dependencies": {
     "@hoangvvo/graphql-jit": "^0.6.1",
-    "flatstr": "^1.0.12",
     "tiny-lru": "^7.0.6"
   },
   "peerDependencies": {

--- a/packages/core/src/flatstr.d.ts
+++ b/packages/core/src/flatstr.d.ts
@@ -1,3 +1,0 @@
-declare module 'flatstr' {
-  export default function flatstr(s: string): string;
-}

--- a/packages/core/src/http.ts
+++ b/packages/core/src/http.ts
@@ -1,6 +1,5 @@
 import Benzene from './core';
 import { HTTPRequest, HTTPResponse, GraphQLParams } from './types';
-import flatstr from 'flatstr';
 import { ExecutionResult, GraphQLError } from 'graphql';
 
 function parseBodyByContentType(
@@ -63,7 +62,7 @@ function createResponse(
   obj: ExecutionResult
 ): HTTPResponse {
   return {
-    body: flatstr(JSON.stringify(gql.formatExecutionResult(obj))),
+    payload: gql.formatExecutionResult(obj),
     status: code,
     headers: { 'content-type': 'application/json' },
   };

--- a/packages/core/src/http.ts
+++ b/packages/core/src/http.ts
@@ -1,5 +1,5 @@
 import Benzene from './core';
-import { HttpQueryRequest, HttpQueryResponse, GraphQLParams } from './types';
+import { HTTPRequest, HTTPResponse, GraphQLParams } from './types';
 import flatstr from 'flatstr';
 import { ExecutionResult, GraphQLError } from 'graphql';
 
@@ -61,7 +61,7 @@ function createResponse(
   gql: Benzene,
   code: number,
   obj: ExecutionResult
-): HttpQueryResponse {
+): HTTPResponse {
   return {
     body: flatstr(JSON.stringify(gql.formatExecutionResult(obj))),
     status: code,
@@ -71,8 +71,8 @@ function createResponse(
 
 export async function runHttpQuery(
   gql: Benzene,
-  request: HttpQueryRequest
-): Promise<HttpQueryResponse> {
+  request: HTTPRequest
+): Promise<HTTPResponse> {
   let body: Record<string, any> | null;
   try {
     body =

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,8 +1,8 @@
 export { default as Benzene } from './core';
 export {
   GraphQLParams,
-  HttpQueryRequest,
-  HttpQueryResponse,
+  HTTPRequest,
+  HTTPResponse,
   FormattedExecutionResult,
   ValueOrPromise,
   TContext,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -32,7 +32,7 @@ export interface HTTPRequest {
 
 export interface HTTPResponse {
   status: number;
-  body: string;
+  payload: FormattedExecutionResult;
   headers: Record<string, string>;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -22,7 +22,7 @@ export interface GraphQLParams {
   extensions?: Record<string, any> | null;
 }
 
-export interface HttpQueryRequest {
+export interface HTTPRequest {
   context: TContext;
   httpMethod: string;
   queryParams: Record<string, string> | null;
@@ -30,7 +30,7 @@ export interface HttpQueryRequest {
   headers: Record<string, string | null>;
 }
 
-export interface HttpQueryResponse {
+export interface HTTPResponse {
   status: number;
   body: string;
   headers: Record<string, string>;

--- a/packages/core/tests/http.spec.ts
+++ b/packages/core/tests/http.spec.ts
@@ -4,7 +4,7 @@ import assert from 'uvu/assert';
 import { GraphQLObjectType, GraphQLString, GraphQLSchema } from 'graphql';
 import {
   Benzene,
-  HttpQueryResponse,
+  HTTPResponse,
   runHttpQuery,
   FormattedExecutionResult,
 } from '../src';
@@ -57,7 +57,7 @@ async function httpTest(
     headers?: Record<string, string>;
     stringifyBody?: boolean;
   },
-  expected: Partial<Omit<HttpQueryResponse, 'body'>> & {
+  expected: Partial<Omit<HTTPResponse, 'body'>> & {
     body?: FormattedExecutionResult | string;
   },
   GQLInstance = GQL

--- a/packages/core/tests/persisted/automatic.spec.ts
+++ b/packages/core/tests/persisted/automatic.spec.ts
@@ -6,7 +6,7 @@ import {
   Benzene,
   runHttpQuery,
   FormattedExecutionResult,
-  HttpQueryResponse,
+  HTTPResponse,
   persistedQueryPresets,
 } from '../../src';
 import { TestSchema } from '../schema.spec';
@@ -28,7 +28,7 @@ async function httpTest(
     headers?: Record<string, string>;
     stringifyBody?: boolean;
   },
-  expected: Partial<Omit<HttpQueryResponse, 'body'>> & {
+  expected: Partial<Omit<HTTPResponse, 'body'>> & {
     body?: FormattedExecutionResult | string;
   },
   GQLInstance = GQL

--- a/packages/core/tests/persisted/persisted.spec.ts
+++ b/packages/core/tests/persisted/persisted.spec.ts
@@ -4,7 +4,7 @@ import {
   Benzene,
   runHttpQuery,
   FormattedExecutionResult,
-  HttpQueryResponse,
+  HTTPResponse,
 } from '../../src';
 import { TestSchema } from '../schema.spec';
 
@@ -31,7 +31,7 @@ async function httpTest(
     headers?: Record<string, string>;
     stringifyBody?: boolean;
   },
-  expected: Partial<Omit<HttpQueryResponse, 'body'>> & {
+  expected: Partial<Omit<HTTPResponse, 'body'>> & {
     body?: FormattedExecutionResult | string;
   },
   GQLInstance = GQL

--- a/packages/server/src/http/handler.ts
+++ b/packages/server/src/http/handler.ts
@@ -1,11 +1,11 @@
-import { Benzene, HttpQueryResponse, runHttpQuery } from '@benzene/core';
+import { Benzene, HTTPResponse, runHttpQuery } from '@benzene/core';
 import { parse as parseQS } from 'querystring';
 import { readBody } from './readBody';
 import { HandlerConfig } from './types';
 import { IncomingMessage, ServerResponse } from 'http';
 
 export function createHandler(gql: Benzene, options: HandlerConfig = {}) {
-  function sendResponse(res: ServerResponse, result: HttpQueryResponse) {
+  function sendResponse(res: ServerResponse, result: HTTPResponse) {
     res.writeHead(result.status, result.headers).end(result.body);
   }
   function sendErrorResponse(res: ServerResponse, error: any) {

--- a/packages/server/src/http/index.ts
+++ b/packages/server/src/http/index.ts
@@ -1,1 +1,1 @@
-export { createHandler } from './handler';
+export { httpHandler } from './handler';

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,2 +1,2 @@
 export * from '@benzene/core';
-export { createHandler as httpHandler } from './http';
+export { httpHandler } from './http';

--- a/packages/worker/src/handler.ts
+++ b/packages/worker/src/handler.ts
@@ -27,7 +27,7 @@ export function createHandler(gql: Benzene, options: HandlerConfig = {}) {
         );
       }
 
-    const { status, body, headers } = await runHttpQuery(gql, {
+    const result = await runHttpQuery(gql, {
       httpMethod: request.method,
       body: request.method === 'POST' ? await request.text() : null,
       queryParams,
@@ -37,7 +37,10 @@ export function createHandler(gql: Benzene, options: HandlerConfig = {}) {
       },
     });
 
-    return new Response(body, { status, headers });
+    return new Response(JSON.stringify(result.payload), {
+      status: result.status,
+      headers: result.headers,
+    });
   }
 
   return function handler(event: FetchEvent) {

--- a/packages/worker/tests/worker.spec.ts
+++ b/packages/worker/tests/worker.spec.ts
@@ -55,7 +55,7 @@ async function testFetch(
       request: new fetch.Request(request),
       respondWith: async (maybeResponse) => {
         const response = await maybeResponse;
-        assert.equal(expected.body, await response.text());
+        assert.equal(expected.payload, await response.json());
         assert.equal(expected.status || 200, response.status);
         // TODO: Add headers
         resolve();
@@ -75,7 +75,7 @@ const suiteFetch = suite('fetchHandler');
 
 suiteFetch('handles GET request', () => {
   return testFetch(new fetch.Request('http://localhost/graphql?query={test}'), {
-    body: JSON.stringify({ data: { test: 'Hello World' } }),
+    payload: { data: { test: 'Hello World' } },
   });
 });
 
@@ -86,14 +86,14 @@ suiteFetch('handles POST request', () => {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ query: '{test}' }),
     }),
-    { body: JSON.stringify({ data: { test: 'Hello World' } }) }
+    { payload: { data: { test: 'Hello World' } } }
   );
 });
 
 suiteFetch('resolves options.context that is an object', async () => {
   await testFetch(
     new fetch.Request('/graphql?query={testCtx}'),
-    { body: `{"data":{"testCtx":"Hello Jane"}}` },
+    { payload: { data: { testCtx: 'Hello Jane' } } },
     { context: { who: 'Jane' } }
   );
 });
@@ -105,7 +105,7 @@ suiteFetch('resolves options.context that is a function', async () => {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ query: '{testCtx}' }),
     }),
-    { body: `{"data":{"testCtx":"Hello John"}}` },
+    { payload: { data: { testCtx: 'Hello John' } } },
     { context: async () => ({ who: 'John' }) }
   );
 });
@@ -118,7 +118,7 @@ suiteFetch('catches error thrown in context function', async () => {
       body: JSON.stringify({ query: '{testCtx}' }),
     }),
     {
-      body: `{"errors":[{"message":"Context creation failed: uh oh"}]}`,
+      payload: { errors: [{ message: 'Context creation failed: uh oh' }] },
       status: 500,
     },
     {

--- a/packages/worker/tests/worker.spec.ts
+++ b/packages/worker/tests/worker.spec.ts
@@ -1,7 +1,7 @@
 import { suite } from 'uvu';
 import assert from 'uvu/assert';
 import * as fetch from 'node-fetch';
-import { HttpQueryResponse } from '@benzene/core/src';
+import { HTTPResponse } from '@benzene/core/src';
 import { Benzene, fetchHandler } from '../src';
 import { GraphQLObjectType, GraphQLString, GraphQLSchema } from 'graphql';
 import { HandlerConfig } from '../src/types';
@@ -45,7 +45,7 @@ const TestSchema = new GraphQLSchema({
 
 async function testFetch(
   request: fetch.Request,
-  expected: Partial<HttpQueryResponse> | null,
+  expected: Partial<HTTPResponse> | null,
   options?: HandlerConfig,
   GQLInstance = new Benzene({ schema: TestSchema })
 ): Promise<void> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1657,11 +1657,6 @@ flat-cache@^2.0.1:
     rimraf "2.6.3"
     write "1.0.3"
 
-flatstr@^1.0.12:
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/flatstr/-/flatstr-1.0.12.tgz#c2ba6a08173edbb6c9640e3055b95e287ceb5931"
-  integrity sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==
-
 flatted@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"


### PR DESCRIPTION
Previously `runHttpQuery` returns a stringified `body` field. This prevents further tweaking on server libraries without re-parsing it.

This PR changes the field `body` to `payload` and returns an object (execution result) instead