### PR TITLE
[docs] Update ws context example to use req.socket

### DIFF
--- a/docs/pages/reference/build-context.md
+++ b/docs/pages/reference/build-context.md
@@ -33,7 +33,7 @@ const graphqlWS = makeHandler(GQL);
 function onConnection(socket, req) {
   const extra = {
     user: "Niko",
-    ip: req.connection.remoteAddress,
+    ip: req.socket.remoteAddress,
   };
   graphqlWS(socket, extra);
 }


### PR DESCRIPTION
`req.connection` has been deprecated as of `v13.0.0` and socket is suggested to be used.