### PR TITLE
fix(types): match `HTTPRequest.body` type to `parseGraphQLBody` return type

### DIFF
--- a/.changeset/little-tools-type.md
+++ b/.changeset/little-tools-type.md
@@ -1,0 +1,5 @@
+---
+"@benzene/http": patch
+---
+
+Match `HTTPRequest.body` type to `parseGraphQLBody` return type

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -11,7 +11,7 @@ type Headers = Record<string, string | string[] | undefined>;
 export interface HTTPRequest {
   method: string;
   query?: Record<string, string | string[]>;
-  body?: Record<string, any>;
+  body?: Record<string, any> | null;
   headers: Headers;
 }
 


### PR DESCRIPTION
Closes #40.