### PR TITLE
fix(types): make `extra` optional on `graphqlHTTP` and `graphqlWS`

### DIFF
--- a/.changeset/shiny-pots-fold.md
+++ b/.changeset/shiny-pots-fold.md
@@ -2,4 +2,4 @@
 "@benzene/http": patch
 ---
 
-Make `extra` optional on `graphqlHTTP`
+Make `extra` optional on `graphqlHTTP` and `graphqlWS`

--- a/.changeset/shiny-pots-fold.md
+++ b/.changeset/shiny-pots-fold.md
@@ -1,0 +1,5 @@
+---
+"@benzene/http": patch
+---
+
+Make `extra` optional on `graphqlHTTP`

--- a/packages/http/__tests__/handler.spec.ts
+++ b/packages/http/__tests__/handler.spec.ts
@@ -681,6 +681,43 @@ test("Receive extra in Benzene#contextFn", async () => {
   });
 });
 
+test("Receive nullable extra in Benzene#contextFn", async () => {
+  const schema = new GraphQLSchema({
+    query: new GraphQLObjectType({
+      name: "Query",
+      fields: {
+        test: {
+          type: GraphQLString,
+          resolve: (_obj, _args, context) => context,
+        },
+      },
+    }),
+  });
+
+  expect(
+    await makeHandler(
+      new Benzene<unknown, unknown>({
+        schema,
+        contextFn: ({ extra }) => extra,
+      })
+    )({
+      method: "GET",
+      query: {
+        query: "{ test }",
+      },
+      headers: {},
+    })
+  ).toEqual({
+    status: 200,
+    headers: { "content-type": "application/json" },
+    payload: {
+      data: {
+        test: null,
+      },
+    },
+  });
+});
+
 // Custom validate function
 // Custom validation rules
 // Custom execute

--- a/packages/http/src/handler.ts
+++ b/packages/http/src/handler.ts
@@ -33,7 +33,7 @@ export function makeHandler<TBenzene extends Benzene>(
    */
   return async function graphqlHTTP(
     request: HTTPRequest,
-    extra: TExtra
+    extra?: TExtra
   ): Promise<HTTPResponse> {
     const params = getGraphQLParams(request);
 

--- a/packages/ws/__tests__/handler.spec.ts
+++ b/packages/ws/__tests__/handler.spec.ts
@@ -7,7 +7,7 @@ import {
   GraphQLSchema,
   GraphQLString,
 } from "graphql";
-import { createServer, IncomingMessage, Server } from "http";
+import { createServer, Server } from "http";
 import { AddressInfo } from "net";
 import WebSocket from "ws";
 import { makeHandler } from "../src/handler";
@@ -380,8 +380,8 @@ test("receive connectionParams in onConnect", async () => {
 test("receive connection context and extra in onConnect", async () => {
   const utils = await startServer({
     // see startServer - makeHandler(socket, request) request is extra
-    onConnect: async (ctx) => ctx.extra instanceof IncomingMessage,
-  });
+    onConnect: async (ctx) => ctx.extra === "foo",
+  }, "foo");
 
   utils.send({ type: MessageType.ConnectionInit });
 

--- a/packages/ws/__tests__/handler.spec.ts
+++ b/packages/ws/__tests__/handler.spec.ts
@@ -381,7 +381,7 @@ test("receive connection context and extra in onConnect", async () => {
   const utils = await startServer({
     // see startServer - makeHandler(socket, request) request is extra
     onConnect: async (ctx) => ctx.extra === "foo",
-  }, "foo");
+  }, undefined, undefined, "foo");
 
   utils.send({ type: MessageType.ConnectionInit });
 

--- a/packages/ws/src/handler.ts
+++ b/packages/ws/src/handler.ts
@@ -154,7 +154,7 @@ export function makeHandler<TBenzene extends Benzene>(
    * @param socket The WebSocket connection {@link https://developer.mozilla.org/en-US/docs/Web/API/WebSocket}
    * @param extra An extra field to store anything that needs to persist throughout connection, accessible in callbacks
    */
-  return function graphqlWS(socket: WebSocket, extra: TExtra) {
+  return function graphqlWS(socket: WebSocket, extra?: TExtra) {
     if (
       socket.protocol === undefined ||
       socket.protocol.indexOf(GRAPHQL_TRANSPORT_WS_PROTOCOL) === -1

--- a/packages/ws/src/types.ts
+++ b/packages/ws/src/types.ts
@@ -49,7 +49,7 @@ export interface ConnectionContext<TExtra> {
   // Whether the server has received connection init request from the client
   connectionInitReceived: boolean;
   // The "extra" variable
-  extra: TExtra;
+  extra?: TExtra;
 }
 
 export interface HandlerOptions<TExtra> {

--- a/packages/ws/src/types.ts
+++ b/packages/ws/src/types.ts
@@ -49,7 +49,7 @@ export interface ConnectionContext<TExtra> {
   // Whether the server has received connection init request from the client
   connectionInitReceived: boolean;
   // The "extra" variable
-  extra?: TExtra;
+  extra: TExtra;
 }
 
 export interface HandlerOptions<TExtra> {


### PR DESCRIPTION
Closes #38 