### PR TITLE
fix(types): make `extra` optional on `ConnectionContext`

### DIFF
--- a/packages/ws/src/types.ts
+++ b/packages/ws/src/types.ts
@@ -49,7 +49,7 @@ export interface ConnectionContext<TExtra> {
   // Whether the server has received connection init request from the client
   connectionInitReceived: boolean;
   // The "extra" variable
-  extra: TExtra;
+  extra?: TExtra | undefined;
 }
 
 export interface HandlerOptions<TExtra> {

--- a/packages/ws/src/types.ts
+++ b/packages/ws/src/types.ts
@@ -49,7 +49,7 @@ export interface ConnectionContext<TExtra> {
   // Whether the server has received connection init request from the client
   connectionInitReceived: boolean;
   // The "extra" variable
-  extra?: TExtra | undefined;
+  extra: TExtra | undefined;
 }
 
 export interface HandlerOptions<TExtra> {


### PR DESCRIPTION
When #46 was merged I forgot to make the `extra` optional on `ConnectionContext`, and we got this error when building:

![image](https://user-images.githubusercontent.com/96476/117129097-2d33c800-ad96-11eb-97dd-dbbe047543fa.png)

This PR fixes that.