### PR TITLE
refactor!(extra): Update APQ implementation

### DIFF
--- a/.changeset/red-ligers-drum.md
+++ b/.changeset/red-ligers-drum.md
@@ -1,0 +1,5 @@
+---
+"@benzene/http": patch
+---
+
+Allows options.onParams to be async

--- a/.changeset/wet-queens-fetch.md
+++ b/.changeset/wet-queens-fetch.md
@@ -2,4 +2,4 @@
 "@benzene/extra": minor
 ---
 
-breaking: changes makeAPQHandler behavior
+refactor!: changes makeAPQHandler behavior

--- a/.changeset/wet-queens-fetch.md
+++ b/.changeset/wet-queens-fetch.md
@@ -1,0 +1,5 @@
+---
+"@benzene/extra": minor
+---
+
+breaking: changes makeAPQHandler behavior

--- a/docs/pages/reference/extra.md
+++ b/docs/pages/reference/extra.md
@@ -29,9 +29,9 @@ See [Automatic Persisted Queries with @benzene/extra](/recipes/persisted-queries
 ```js
 import { makeAPQHandler } from "@benzene/extra";
 
-const apqHTTP = makeAPQHandler();
+const apq = makeAPQHandler();
 // or use a custom cache
-const apqHTTP = makeAPQHandler({
+const apq = makeAPQHandler({
   cache: lru(1024),
 });
 

--- a/docs/pages/reference/extra.md
+++ b/docs/pages/reference/extra.md
@@ -35,7 +35,38 @@ const apqHTTP = makeAPQHandler({
   cache: lru(1024),
 });
 
-await appHTTP(bodyOrQueryObject); // `appHTTP` mutates and returns `bodyOrQueryObject`
+const params = {
+  query: undefined, // query not included
+  extensions: {
+    persistedQuery: {
+      sha256Hash: "ec2e01311ab3b02f3d8c8c712f9e579356d332cd007ac4c1ea5df727f482f05f",
+      version: 1,
+    },
+  },
+}
+
+const newParamsOrResult = await appHTTP(bodyOrQueryObject);
+console.log(newParamsOrResult);
+// If query is found:
+// {
+//   "query": "query { hello }",
+//   "extensions": {
+//     "persistedQuery": {
+//       "sha256Hash": "ec2e01311ab3b02f3d8c8c712f9e579356d332cd007ac4c1ea5df727f482f05f",
+//       "version": 1
+//     }
+//   }
+// }
+// Otherwise:
+// {
+//   "errors": [
+//     {
+//       "message": "PersistedQueryNotFound",
+//       "extensions": { "code": "PERSISTED_QUERY_NOT_FOUND" },
+//       "status": 200
+//     }
+//   ]
+// }
 ```
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12007,6 +12007,9 @@
         "crypto-hash": "^1.3.0",
         "tiny-lru": "^7.0.6"
       },
+      "devDependencies": {
+        "@benzene/core": "^0.6.0"
+      },
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -13174,6 +13177,7 @@
     "@benzene/extra": {
       "version": "file:packages/extra",
       "requires": {
+        "@benzene/core": "*",
         "crypto-hash": "^1.3.0",
         "tiny-lru": "^7.0.6"
       }

--- a/packages/extra/__tests__/apq.spec.ts
+++ b/packages/extra/__tests__/apq.spec.ts
@@ -2,7 +2,7 @@ import { makeAPQHandler } from "@benzene/extra/src/apq";
 import { sha256 } from "crypto-hash";
 import lru from "tiny-lru";
 
-test("does nothing if input is not object or does not contain a supported persisted query", async () => {
+test("does nothing if inputs does not contain a supported persisted query", async () => {
   const badCache = {};
   // @ts-expect-error: It should not invoke cache in the cases below
   const apqHTTP = makeAPQHandler({ cache: badCache });
@@ -10,12 +10,6 @@ test("does nothing if input is not object or does not contain a supported persis
   const req = {};
   const res = await apqHTTP(req);
   expect(res).toBe(req);
-
-  const res1 = await apqHTTP(undefined);
-  expect(res1).toBeUndefined();
-
-  const res2 = await apqHTTP(null);
-  expect(res2).toBeNull();
 
   const req3 = { extensions: { persistedQuery: { version: 2 } } };
   const res3 = await apqHTTP(req3);
@@ -26,9 +20,9 @@ test("does nothing if input is not object or does not contain a supported persis
   expect(res4).toBe(req4);
 });
 
-test("throws PersistedQueryNotFound is query hash is not recognized", () => {
+test("returns result with PersistedQueryNotFound if query hash is not recognized", async () => {
   return expect(
-    makeAPQHandler()({
+    await makeAPQHandler()({
       extensions: {
         persistedQuery: {
           sha256Hash: sha256("{test}"),
@@ -36,20 +30,15 @@ test("throws PersistedQueryNotFound is query hash is not recognized", () => {
         },
       },
     })
-  ).rejects.toThrowError("PersistedQueryNotFound");
-});
-
-test("throws PersistedQueryNotFound is query hash is not found", () => {
-  return expect(
-    makeAPQHandler()({
-      extensions: {
-        persistedQuery: {
-          sha256Hash: sha256("{test}"),
-          version: 1,
-        },
+  ).toEqual({
+    errors: [
+      {
+        message: "PersistedQueryNotFound",
+        extensions: { code: "PERSISTED_QUERY_NOT_FOUND" },
+        status: 200,
       },
-    })
-  ).rejects.toThrowError("PersistedQueryNotFound");
+    ],
+  });
 });
 
 test("allows custom cache", (done) => {
@@ -84,32 +73,11 @@ test("saves query by hash sent from clients", async () => {
     },
   };
   const result = await makeAPQHandler({ cache })(request);
-  expect(result).toBe(request);
+  expect(result).toBe(request); // Return the original params
   expect(cache.get(sha256Hash)).toBe(query);
 });
 
-test("saves query by hash sent from clients (query strings)", async () => {
-  const cache = lru();
-  const sha256Hash = await sha256("{test}");
-
-  const request = {
-    query: "{test}",
-    extensions: JSON.stringify({
-      persistedQuery: {
-        sha256Hash,
-        version: 1,
-      },
-    }),
-  };
-
-  const result = await makeAPQHandler({ cache })(request);
-
-  expect(result).toBe(request);
-
-  expect(cache.get(sha256Hash)).toBe("{test}");
-});
-
-test("throws error if receiving mismatched hash256", async () => {
+test("return result with error if receiving mismatched hash256", async () => {
   const sha256Hash = await sha256("{test}");
 
   const cache = lru();
@@ -117,7 +85,7 @@ test("throws error if receiving mismatched hash256", async () => {
   cache.set(sha256Hash, "{test}");
 
   return expect(
-    makeAPQHandler()({
+    await makeAPQHandler()({
       query: "{test}",
       extensions: {
         persistedQuery: {
@@ -126,7 +94,9 @@ test("throws error if receiving mismatched hash256", async () => {
         },
       },
     })
-  ).rejects.toThrowError("provided sha does not match query");
+  ).toEqual({
+    errors: [{ message: "provided sha does not match query", status: 400 }],
+  });
 });
 
 test("adds query if hash is found in cache", async () => {
@@ -147,30 +117,6 @@ test("adds query if hash is found in cache", async () => {
 
   const result = await makeAPQHandler({ cache })(request);
 
-  expect(result).toBe(request);
-
-  expect(request.query).toBe("{test}");
-});
-
-test("adds query if hash is found in cache (query strings)", async () => {
-  const sha256Hash = await sha256("{test}");
-
-  const request = {
-    extensions: JSON.stringify({
-      persistedQuery: {
-        sha256Hash,
-        version: 1,
-      },
-    }),
-  } as any;
-
-  const cache = lru();
-
-  cache.set(sha256Hash, "{test}");
-
-  const result = await makeAPQHandler({ cache })(request);
-
-  expect(result).toBe(request);
-
-  expect(request.query).toBe("{test}");
+  // @ts-ignore
+  expect(result.query).toBe("{test}");
 });

--- a/packages/extra/__tests__/apq.spec.ts
+++ b/packages/extra/__tests__/apq.spec.ts
@@ -8,18 +8,18 @@ import lru from "tiny-lru";
 test("does nothing if inputs does not contain a supported persisted query", async () => {
   const badCache = {};
   // @ts-expect-error: It should not invoke cache in the cases below
-  const apqHTTP = makeAPQHandler({ cache: badCache });
+  const apq = makeAPQHandler({ cache: badCache });
 
   const req = {};
-  const res = await apqHTTP(req);
+  const res = await apq(req);
   expect(res).toBe(req);
 
   const req3 = { extensions: { persistedQuery: { version: 2 } } };
-  const res3 = await apqHTTP(req3);
+  const res3 = await apq(req3);
   expect(res3).toBe(req3);
 
   const req4 = { extensions: { persisted: "foo" } };
-  const res4 = await apqHTTP(req4);
+  const res4 = await apq(req4);
   expect(res4).toBe(req4);
 });
 

--- a/packages/extra/package.json
+++ b/packages/extra/package.json
@@ -26,7 +26,9 @@
     "require": "./dist/index.cjs"
   },
   "types": "./dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "sideEffects": false,
   "scripts": {
     "build": "tsc --emitDeclarationOnly --project tsconfig.build.json && rollup -c",
@@ -42,5 +44,8 @@
   },
   "engines": {
     "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+  },
+  "devDependencies": {
+    "@benzene/core": "^0.6.0"
   }
 }

--- a/packages/extra/src/apq.ts
+++ b/packages/extra/src/apq.ts
@@ -9,7 +9,7 @@ export function makeAPQHandler(options?: {
   cache?: Pick<KeyValueStore, "get" | "set">;
 }) {
   const cache = options?.cache || lru(1024);
-  return async function apqHTTP(
+  return async function apq(
     params: GraphQLParams
   ): Promise<GraphQLParams | ExecutionResult> {
     if (params.extensions?.persistedQuery?.version !== 1) {

--- a/packages/extra/src/apq.ts
+++ b/packages/extra/src/apq.ts
@@ -1,4 +1,6 @@
+import type { GraphQLParams } from "@benzene/core";
 import { sha256 } from "crypto-hash";
+import { ExecutionResult } from "graphql";
 import lru from "tiny-lru";
 import { HTTPError } from "./errors";
 import { KeyValueStore } from "./types";
@@ -8,34 +10,49 @@ export function makeAPQHandler(options?: {
 }) {
   const cache = options?.cache || lru(1024);
   return async function apqHTTP(
-    bodyOrQuery: Record<string, string | object> | null | undefined
-  ) {
-    if (!bodyOrQuery || typeof bodyOrQuery !== "object") return bodyOrQuery;
-    const extensions: Record<string, any> =
-      typeof bodyOrQuery.extensions === "string"
-        ? JSON.parse(bodyOrQuery.extensions)
-        : bodyOrQuery.extensions;
-    if (extensions?.persistedQuery?.version !== 1) {
+    params: GraphQLParams
+  ): Promise<GraphQLParams | ExecutionResult> {
+    if (params.extensions?.persistedQuery?.version !== 1) {
       // Persisted Queries not supported
-      return bodyOrQuery;
+      return params;
     }
-    const queryHash = extensions.persistedQuery.sha256Hash;
-    if (!bodyOrQuery.query) {
+    const queryHash = params.extensions.persistedQuery.sha256Hash;
+    if (!params.query) {
       // Try get persisted query from store
       const query = cache.get(queryHash);
+
+      console.log(
+        JSON.stringify(
+          new HTTPError(200, "PersistedQueryNotFound", {
+            code: "PERSISTED_QUERY_NOT_FOUND",
+          })
+        ),
+        JSON.stringify(new HTTPError(400, "provided sha does not match query"))
+      );
+
       if (!query) {
-        throw new HTTPError(200, "PersistedQueryNotFound", {
-          code: "PERSISTED_QUERY_NOT_FOUND",
-        });
+        return {
+          errors: [
+            new HTTPError(200, "PersistedQueryNotFound", {
+              code: "PERSISTED_QUERY_NOT_FOUND",
+            }),
+          ],
+        };
       }
-      bodyOrQuery.query = query;
-      return bodyOrQuery;
+
+      return {
+        ...params,
+        query,
+      };
     }
     // Save persited query
-    const computedQueryHash = await sha256(bodyOrQuery.query as string);
-    if (computedQueryHash !== queryHash)
-      throw new HTTPError(400, "provided sha does not match query");
-    cache.set(queryHash, bodyOrQuery.query as string);
-    return bodyOrQuery;
+    const computedQueryHash = await sha256(params.query);
+    if (computedQueryHash !== queryHash) {
+      return {
+        errors: [new HTTPError(400, "provided sha does not match query")],
+      };
+    }
+    cache.set(queryHash, params.query);
+    return params;
   };
 }

--- a/packages/http/__tests__/handler.spec.ts
+++ b/packages/http/__tests__/handler.spec.ts
@@ -720,6 +720,31 @@ describe("options.onParams", () => {
     });
   });
 
+  test("Overrides options.onParams if it returns a promise of GraphQLParams object", async () => {
+    expect(
+      await makeHandler(GQL, {
+        onParams(params) {
+          return Promise.resolve({
+            ...params,
+            query: "{ foo }",
+          });
+        },
+      })({
+        method: "GET",
+        query: {}, // query.query is intentionally empty
+        headers: {},
+      })
+    ).toEqual({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      payload: {
+        data: {
+          foo: "FooValue",
+        },
+      },
+    });
+  });
+
   test("Responds early if it returns an ExecutionResult", async () => {
     expect(
       await makeHandler(GQL, {

--- a/packages/http/src/handler.ts
+++ b/packages/http/src/handler.ts
@@ -38,7 +38,7 @@ export function makeHandler<TBenzene extends Benzene>(
     let params = getGraphQLParams(request);
 
     if (options.onParams) {
-      const onParamsResult = options.onParams(params);
+      const onParamsResult = await options.onParams(params);
       if (onParamsResult) {
         if (isExecutionResult(onParamsResult)) {
           return createResponse(GQL, 200, onParamsResult);

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -1,4 +1,4 @@
-import { GraphQLParams } from "@benzene/core";
+import { GraphQLParams, ValueOrPromise } from "@benzene/core";
 import { ExecutionResult, FormattedExecutionResult } from "graphql";
 
 // @ts-ignore
@@ -8,7 +8,9 @@ export interface HandlerOptions<TExtra> {
    * either the new GraphQLParams or ExecutionResult
    * @param params
    */
-  onParams?(params: GraphQLParams): GraphQLParams | ExecutionResult | void;
+  onParams?(
+    params: GraphQLParams
+  ): ValueOrPromise<GraphQLParams | ExecutionResult | void>;
 }
 
 type Headers = Record<string, string | string[] | undefined>;


### PR DESCRIPTION
Previously, `apq()` from `makeAPQHandler` will throw an error in the two cases: `PERSISTED_QUERY_NOT_FOUND` or `provided sha does not match query`. This change makes it returns the error as an `ExecutionResult` instead.